### PR TITLE
Add Alpine Linux variant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,71 +5,103 @@ language: shell
 services:
   - docker
 
-env:
-  - RUBY_VERSION=3.0.3 ALIAS=3.0 LATEST=true
-  - RUBY_VERSION=3.0.2
-  - RUBY_VERSION=3.0.1
-  - RUBY_VERSION=3.0.0
-  - RUBY_VERSION=2.7.5 ALIAS=2.7
-  - RUBY_VERSION=2.7.4
-  - RUBY_VERSION=2.7.3
-  - RUBY_VERSION=2.7.2
-  - RUBY_VERSION=2.7.1
-  - RUBY_VERSION=2.7.0
-  - RUBY_VERSION=2.6.9 ALIAS=2.6
-  - RUBY_VERSION=2.6.8
-  - RUBY_VERSION=2.6.7
-  - RUBY_VERSION=2.6.6
-  - RUBY_VERSION=2.6.5
-  - RUBY_VERSION=2.6.4
-  - RUBY_VERSION=2.6.3
-  - RUBY_VERSION=2.6.2
-  - RUBY_VERSION=2.6.1
-  - RUBY_VERSION=2.6.0
-  - RUBY_VERSION=2.5.9 ALIAS=2.5
-  - RUBY_VERSION=2.5.8
-  - RUBY_VERSION=2.5.7
-  - RUBY_VERSION=2.5.6
-  - RUBY_VERSION=2.5.5
-  - RUBY_VERSION=2.5.4
-  - RUBY_VERSION=2.5.3
-  # - RUBY_VERSION=2.5.2 # Base image has no such tag :-(
-  - RUBY_VERSION=2.5.1
-  - RUBY_VERSION=2.5.0
-  - RUBY_VERSION=2.4.10 ALIAS=2.4
-  - RUBY_VERSION=2.4.9
-  - RUBY_VERSION=2.4.8
-  - RUBY_VERSION=2.4.7
-  - RUBY_VERSION=2.4.6
-  - RUBY_VERSION=2.4.5
-  - RUBY_VERSION=2.4.4
-  - RUBY_VERSION=2.4.3
-  - RUBY_VERSION=2.4.2
-  - RUBY_VERSION=2.4.1
-  - RUBY_VERSION=2.4.0
-  - RUBY_VERSION=2.3.8 ALIAS=2.3
-  - RUBY_VERSION=2.3.7
-  - RUBY_VERSION=2.3.6
-  - RUBY_VERSION=2.3.5
-  - RUBY_VERSION=2.3.4
-  - RUBY_VERSION=2.3.3
-  - RUBY_VERSION=2.3.2
-  - RUBY_VERSION=2.3.1
-  - RUBY_VERSION=2.3.0
-
 before_script:
   - echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USER}" --password-stdin
 
-script:
-  - docker build .
-      --build-arg BASE_IMAGE_TAG=${RUBY_VERSION}
-      --tag alpinelab/ruby-dev:${RUBY_VERSION}
-      ${ALIAS:+--tag alpinelab/ruby-dev:${ALIAS}}
-      ${LATEST:+--tag alpinelab/ruby-dev:latest}
-  - if [[ ${TRAVIS_BRANCH} = "master" && -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
-      [[ -n ${ALIAS} ]] && docker push alpinelab/ruby-dev:${ALIAS} || echo "No alias to push";
-      [[ -n ${LATEST} ]] && docker push alpinelab/ruby-dev:latest || echo "Not the latest version";
-      docker push alpinelab/ruby-dev:${RUBY_VERSION};
-    else
-      echo "This is not a commit on master. Not pushing the built image anywhere.";
-    fi
+script: ./build.sh
+
+env:
+  global:
+    - DOCKER_BUILDKIT=1
+  jobs:
+    - RUBY_VERSION=3.0.3        ALIAS=3.0,latest
+    - RUBY_VERSION=3.0.3-alpine ALIAS=3.0-alpine,alpine
+    - RUBY_VERSION=3.0.2
+    - RUBY_VERSION=3.0.2-alpine
+    - RUBY_VERSION=3.0.1
+    - RUBY_VERSION=3.0.1-alpine
+    - RUBY_VERSION=3.0.0
+    - RUBY_VERSION=3.0.0-alpine
+    - RUBY_VERSION=2.7.5        ALIAS=2.7
+    - RUBY_VERSION=2.7.5-alpine ALIAS=2.7-alpine
+    - RUBY_VERSION=2.7.4
+    - RUBY_VERSION=2.7.4-alpine
+    - RUBY_VERSION=2.7.3
+    - RUBY_VERSION=2.7.3-alpine
+    - RUBY_VERSION=2.7.2
+    - RUBY_VERSION=2.7.2-alpine
+    - RUBY_VERSION=2.7.1
+    - RUBY_VERSION=2.7.1-alpine
+    - RUBY_VERSION=2.7.0
+    - RUBY_VERSION=2.7.0-alpine
+    - RUBY_VERSION=2.6.9        ALIAS=2.6
+    - RUBY_VERSION=2.6.9-alpine ALIAS=2.6-alpine
+    - RUBY_VERSION=2.6.8
+    - RUBY_VERSION=2.6.8-alpine
+    - RUBY_VERSION=2.6.7
+    - RUBY_VERSION=2.6.7-alpine
+    - RUBY_VERSION=2.6.6
+    - RUBY_VERSION=2.6.6-alpine
+    - RUBY_VERSION=2.6.5
+    - RUBY_VERSION=2.6.5-alpine
+    - RUBY_VERSION=2.6.4
+    - RUBY_VERSION=2.6.4-alpine
+    - RUBY_VERSION=2.6.3
+    - RUBY_VERSION=2.6.3-alpine
+    - RUBY_VERSION=2.6.2
+    - RUBY_VERSION=2.6.2-alpine
+    - RUBY_VERSION=2.6.1
+    - RUBY_VERSION=2.6.1-alpine
+    - RUBY_VERSION=2.6.0
+    - RUBY_VERSION=2.6.0-alpine
+    - RUBY_VERSION=2.5.9        ALIAS=2.5
+    - RUBY_VERSION=2.5.9-alpine ALIAS=2.5-alpine
+    - RUBY_VERSION=2.5.8
+    - RUBY_VERSION=2.5.8-alpine
+    - RUBY_VERSION=2.5.7
+    - RUBY_VERSION=2.5.7-alpine
+    - RUBY_VERSION=2.5.6
+    - RUBY_VERSION=2.5.6-alpine
+    - RUBY_VERSION=2.5.5
+    - RUBY_VERSION=2.5.5-alpine
+    - RUBY_VERSION=2.5.4
+    - RUBY_VERSION=2.5.4-alpine
+    - RUBY_VERSION=2.5.3
+    - RUBY_VERSION=2.5.3-alpine
+    # Ruby 2.5.2 never existed: it was mis-packaged and 2.5.3 was released immediately to fix this.
+    - RUBY_VERSION=2.5.1
+    - RUBY_VERSION=2.5.1-alpine
+    - RUBY_VERSION=2.5.0
+    - RUBY_VERSION=2.5.0-alpine
+    - RUBY_VERSION=2.4.10        ALIAS=2.4
+    - RUBY_VERSION=2.4.10-alpine ALIAS=2.4-alpine
+    - RUBY_VERSION=2.4.9
+    - RUBY_VERSION=2.4.9-alpine
+    - RUBY_VERSION=2.4.8
+    - RUBY_VERSION=2.4.8-alpine
+    - RUBY_VERSION=2.4.7
+    - RUBY_VERSION=2.4.7-alpine
+    - RUBY_VERSION=2.4.6
+    - RUBY_VERSION=2.4.6-alpine
+    - RUBY_VERSION=2.4.5
+    - RUBY_VERSION=2.4.5-alpine
+    - RUBY_VERSION=2.4.4
+    - RUBY_VERSION=2.4.4-alpine
+    - RUBY_VERSION=2.4.3
+    - RUBY_VERSION=2.4.3-alpine3.7 ALIAS=2.4.3-alpine
+    - RUBY_VERSION=2.4.2
+    - RUBY_VERSION=2.4.2-alpine3.7 ALIAS=2.4.2-alpine
+    - RUBY_VERSION=2.4.1
+    - RUBY_VERSION=2.4.1-alpine3.6 ALIAS=2.4.1-alpine
+    - RUBY_VERSION=2.4.0 # No Alpine variant because Yarn is unavailable on this Alpine version (< 3.6)
+    - RUBY_VERSION=2.3.8        ALIAS=2.3
+    - RUBY_VERSION=2.3.8-alpine ALIAS=2.3-alpine
+    - RUBY_VERSION=2.3.7
+    - RUBY_VERSION=2.3.7-alpine
+    - RUBY_VERSION=2.3.6 # No Alpine variant because Yarn is unavailable on this Alpine version (< 3.6)
+    - RUBY_VERSION=2.3.5 # No Alpine variant because Yarn is unavailable on this Alpine version (< 3.6)
+    - RUBY_VERSION=2.3.4 # No Alpine variant because Yarn is unavailable on this Alpine version (< 3.6)
+    - RUBY_VERSION=2.3.3 # No Alpine variant because Yarn is unavailable on this Alpine version (< 3.6)
+    - RUBY_VERSION=2.3.2 # No Alpine variant because Yarn is unavailable on this Alpine version (< 3.6)
+    - RUBY_VERSION=2.3.1 # No Alpine variant because Yarn is unavailable on this Alpine version (< 3.6)
+    - RUBY_VERSION=2.3.0 # No Alpine variant because Yarn is unavailable on this Alpine version (< 3.6)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG BASE_IMAGE_TAG=latest
 
 FROM ruby:${BASE_IMAGE_TAG}
@@ -26,62 +28,125 @@ ENV PORT="5000" \
     GIT_COMMITTER_EMAIL="whatever@this-user-is-not-supposed-to-git-push.anyway" \
     DISABLE_SPRING="true"
 
-# Install APT dependencies
-RUN sed -i '/jessie-updates/d' /etc/apt/sources.list \
- && apt-get update \
- && apt-get install --assume-yes --no-install-recommends --no-install-suggests \
-      apt-transport-https \
-      lsb-release \
- && debianReleaseCodename=$(lsb_release -cs) \
- \
- && case "${debianReleaseCodename}" in jessie|buster|stretch) \
-      apt-get install --assume-yes --no-install-recommends --no-install-suggests \
-        ca-certificates \
-        curl \
-        $([ "${debianReleaseCodename}" = "jessie" ] && echo libssl1.0.0) \
-      && sed -i 's|mozilla/DST_Root_CA_X3.crt|!mozilla/DST_Root_CA_X3.crt|g' /etc/ca-certificates.conf \
-      && update-ca-certificates; \
-    ;; esac \
- \
- && curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg \
- && case "${debianReleaseCodename}" in \
-      jessie) echo "deb https://apt-archive.postgresql.org/pub/repos/apt ${debianReleaseCodename}-pgdg-archive main" ;; \
-      *) echo "deb https://apt.postgresql.org/pub/repos/apt/ ${debianReleaseCodename}-pgdg main" ;; \
-    esac > /etc/apt/sources.list.d/pgdg.list \
- \
- && curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.nodesource.com.gpg \
- && case "${debianReleaseCodename}" in \
-      jessie) echo "deb https://deb.nodesource.com/node_14.x ${debianReleaseCodename} main" ;; \
-      *) echo "deb https://deb.nodesource.com/node_${NODE_VERSION}.x ${debianReleaseCodename} main" ;; \
-    esac > /etc/apt/sources.list.d/nodesource.list \
- \
- && curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.yarnpkg.com.gpg \
- && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
- \
- && curl -sSL https://cli-assets.heroku.com/apt/release.key | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.heroku.com.gpg \
- && echo "deb https://cli-assets.heroku.com/branches/stable/apt ./" > /etc/apt/sources.list.d/heroku.list \
- \
- && apt-get update \
- && apt-get install --assume-yes --no-install-recommends --no-install-suggests \
-      heroku \
-      jq \
-      nano \
-      nodejs \
-      postgresql-client \
-      vim \
-      yarn \
- \
- && rm -rf /var/lib/apt/lists/*
+# Install dependencies
+RUN set -eux; \
+    osType="$(sed -n 's|^ID=||p' /etc/os-release)"; \
+    \
+    case "${osType}" in \
+      alpine) \
+        alpineMajorVersion=$(sed -nr 's/^VERSION_ID=(\d+\.\d+).*/\1/p' /etc/os-release); \
+        \
+        # Use `libpq-dev` (~20MB) rather than `postgresql-dev` (~200MB) if available
+        # (the former was extracted from the latter in Alpine 3.15)
+        case ${alpineMajorVersion} in \
+          3.3|3.4|3.5|3.6|3.7|3.8|3.9|3.10|3.11|3.12|3.13|3.14) libpqPackage="postgresql-dev" ;; \
+          3.15|*) libpqPackage="libpq-dev" ;; \
+        esac; \
+        \
+        apk add --no-cache \
+          alpine-sdk \
+          openssh \
+          jq \
+          nano \
+          nodejs \
+          postgresql \
+          vim \
+          yarn \
+          ${libpqPackage} \
+        ; \
+      ;; \
+      \
+      debian|ubuntu) \
+        # Fix Jessie APT sources
+        sed -i '/jessie-updates/d' /etc/apt/sources.list; \
+        \
+        # Install some prerequisites
+        apt-get update; \
+        apt-get install --assume-yes --no-install-recommends --no-install-suggests \
+          apt-transport-https \
+          lsb-release \
+        ; \
+        debianReleaseCodename=$(lsb_release -cs); \
+        \
+        # Fix LetsEncrypt expired CA on older Debian releases
+        case ${debianReleaseCodename} in \
+          jessie|buster|stretch) \
+            apt-get install --assume-yes --no-install-recommends --no-install-suggests \
+              ca-certificates \
+              curl \
+              $([ "${debianReleaseCodename}" = "jessie" ] && echo libssl1.0.0) \
+            ; \
+            sed -i 's|mozilla/DST_Root_CA_X3.crt|!mozilla/DST_Root_CA_X3.crt|g' /etc/ca-certificates.conf; \
+            update-ca-certificates; \
+          ;; \
+        esac; \
+        \
+        # Add PostgreSQL APT reposiroty
+        curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg; \
+        case ${debianReleaseCodename} in \
+          jessie) echo "deb https://apt-archive.postgresql.org/pub/repos/apt ${debianReleaseCodename}-pgdg-archive main" ;; \
+          *) echo "deb https://apt.postgresql.org/pub/repos/apt/ ${debianReleaseCodename}-pgdg main" ;; \
+        esac > /etc/apt/sources.list.d/pgdg.list; \
+        \
+        # Add NodeJS APT repository
+        curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.nodesource.com.gpg; \
+        case ${debianReleaseCodename} in \
+          jessie) echo "deb https://deb.nodesource.com/node_14.x ${debianReleaseCodename} main" ;; \
+          *) echo "deb https://deb.nodesource.com/node_${NODE_VERSION}.x ${debianReleaseCodename} main" ;; \
+        esac > /etc/apt/sources.list.d/nodesource.list; \
+        \
+        # Add Yarn APT repository
+        curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.yarnpkg.com.gpg; \
+        echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list; \
+        \
+        # Add Heroku APT repository
+        curl -sSL https://cli-assets.heroku.com/apt/release.key | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.heroku.com.gpg; \
+        echo "deb https://cli-assets.heroku.com/branches/stable/apt ./" > /etc/apt/sources.list.d/heroku.list; \
+        \
+        # Install everything
+        apt-get update; \
+        apt-get install --assume-yes --no-install-recommends --no-install-suggests \
+          heroku \
+          jq \
+          nano \
+          nodejs \
+          postgresql-client \
+          vim \
+          yarn \
+        ; \
+        \
+        # Cleanup
+        rm -rf /var/lib/apt/lists/*; \
+      ;; \
+    esac;
 
 # Install `gosu`
-RUN export GNUPGHOME="$(mktemp -d)" dpkgArch="$(dpkg --print-architecture | cut -d- -f1)" \
- && for keyserver in $(shuf -e keys.gnupg.net ha.pool.sks-keyservers.net hkp://p80.pool.sks-keyservers.net:80 keyserver.ubuntu.com pgp.mit.edu); do \
-      gpg --batch --no-tty --keyserver "$keyserver" --recv-keys "B42F6819007F00F88E364FD4036A9C25BF357DD4" && break || :; \
-    done \
- && curl -sSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}" \
- && curl -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}.asc" | gpg --batch --verify - /usr/local/bin/gosu \
- && chmod +x /usr/local/bin/gosu \
- && rm -rf "${GNUPGHOME}"
+ARG TARGETARCH
+RUN set -eux; \
+    osType="$(sed -n 's|^ID=||p' /etc/os-release)"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    \
+    # Install GPG on Alpine (for signature verification)
+    [ "${osType}" = "alpine" ] && apk add --no-cache --virtual .gosu-deps gnupg || :; \
+    \
+    # Fetch author public key
+    for keyserver in $(shuf -e keys.gnupg.net ha.pool.sks-keyservers.net hkp://p80.pool.sks-keyservers.net:80 keyserver.ubuntu.com pgp.mit.edu); do \
+      gpg --batch --no-tty --keyserver "${keyserver}" --recv-keys "B42F6819007F00F88E364FD4036A9C25BF357DD4" && break || :; \
+    done; \
+    \
+    # Download binary
+    curl -sSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${TARGETARCH}"; \
+    chmod +x /usr/local/bin/gosu; \
+    \
+    # Verify binary signature
+    curl -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${TARGETARCH}.asc" \
+      | gpg --batch --verify - /usr/local/bin/gosu; \
+    \
+    # Cleanup
+    command -v gpgconf && gpgconf --kill all || :; \
+    rm -rf "${GNUPGHOME}"; \
+    unset -v GNUPGHOME; \
+    [ "${osType}" = "alpine" ] && apk del --no-network .gosu-deps || :;
 
 # Install GEM dependencies
 # Note: we still need Bundler 1.x because Bundler auto-switches to it when it encounters a Gemfile.lock with BUNDLED WITH 1.x
@@ -91,6 +156,9 @@ RUN gem update --system ${RUBYGEMS_VERSION} \
 
 # Add dot files to the home directory skeleton (they persist IRB/Pry/Rails console history, configure Yarn, etc…)
 COPY dotfiles/* /etc/skel/
+
+# Create expected mount points
+RUN mkdir -p /app /bundle /config
 
 # Configure the main working directory.
 WORKDIR /app

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -ev
+
+### Build
+
+docker build . \
+  --build-arg BASE_IMAGE_TAG=${RUBY_VERSION} \
+  --tag alpinelab/ruby-dev:${RUBY_VERSION} \
+  $(
+    for alias in ${ALIAS//,/ }; do
+      echo "--tag alpinelab/ruby-dev:${alias}"
+    done
+  )
+
+### Publish
+
+if [[ ${TRAVIS_BRANCH} = "master" && -z ${TRAVIS_PULL_REQUEST_BRANCH} ]]; then
+  # Publish with base image name
+  docker push alpinelab/ruby-dev:${RUBY_VERSION}
+  # Publish as aliases
+  for alias in ${ALIAS//,/ }; do
+    docker push alpinelab/ruby-dev:${alias}
+  done
+else
+  echo "This is not a commit on \`master\`: skip publishing.";
+fi

--- a/entrypoints/bundler-entrypoint
+++ b/entrypoints/bundler-entrypoint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Skip this entrypoint if `DISABLE_AUTO_INSTALL_DEPS` is set
 if [ "${DISABLE_AUTO_INSTALL_DEPS}" = "1" ]; then

--- a/entrypoints/foreman-entrypoint
+++ b/entrypoints/foreman-entrypoint
@@ -1,5 +1,5 @@
-#!/bin/bash
+#!/bin/sh
 
-which foreman > /dev/null || gem install --silent foreman
+command -v foreman > /dev/null || gem install --silent foreman
 
 exec "$@"

--- a/entrypoints/gosu-entrypoint
+++ b/entrypoints/gosu-entrypoint
@@ -1,31 +1,56 @@
-#!/bin/bash
+#!/bin/sh
+
+if ! mountpoint -q /app; then
+  exec "$@"
+  exit 0
+fi
 
 export APP_USER_NAME="user"
+export APP_USER_UID="$(stat -c '%u' /app)"
+export APP_USER_GID="$(stat -c '%g' /app)"
 
 if ! grep -q "^${APP_USER_NAME}:" /etc/group; then
-  groupadd                           \
-    --gid $(stat --format '%g' /app) \
-    --non-unique                     \
-    ${APP_USER_NAME} &> /dev/null
+
+  # Create group
+  case "$(sed -n 's|^ID=||p' /etc/os-release)" in
+    alpine)
+      addgroup -g ${APP_USER_GID} ${APP_USER_NAME}
+    ;;
+    debian|ubuntu)
+      groupadd \
+        --gid ${APP_USER_GID} \
+        --non-unique \
+        ${APP_USER_NAME}
+    ;;
+  esac
 fi
 
 if ! grep -q "^${APP_USER_NAME}:" /etc/passwd; then
-  useradd                            \
-    --shell "/bin/bash"              \
-    --uid $(stat --format '%u' /app) \
-    --gid $(stat --format '%g' /app) \
-    --no-user-group                  \
-    --comment "Docker Ruby dev <3"   \
-    --non-unique                     \
-    --create-home                    \
-    ${APP_USER_NAME} &> /dev/null
+
+  # Create user
+  case "$(sed -n 's|^ID=||p' /etc/os-release)" in
+    alpine)
+      adduser -D -u ${APP_USER_UID} -G ${APP_USER_NAME} ${APP_USER_NAME}
+    ;;
+    debian|ubuntu)
+      useradd \
+        --shell "/bin/bash" \
+        --uid ${APP_USER_UID} \
+        --gid ${APP_USER_GID} \
+        --no-user-group \
+        --non-unique \
+        --create-home \
+        ${APP_USER_NAME}
+    ;;
+  esac
 fi
 
-node_modules_path=$(grep node_modules /etc/mtab | cut -d' ' -f2)
+node_modules_mountpoint=$(grep node_modules /etc/mtab | cut -d' ' -f2)
 
-chown --silent --recursive ${APP_USER_NAME}:${APP_USER_NAME} \
-  /bundle                                                    \
-  /config                                                    \
-  ${node_modules_path}
+# Change ownership (this may take a few seconds, but only the first time)
+chown -Rf ${APP_USER_NAME}:${APP_USER_NAME} \
+  /bundle \
+  /config \
+  ${node_modules_mountpoint}
 
 gosu ${APP_USER_NAME} "$@"

--- a/entrypoints/rails-entrypoint
+++ b/entrypoints/rails-entrypoint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Remove rails server PID file, that is sometimes not properly removed at shutdown
 # as instructed in https://docs.docker.com/compose/rails/

--- a/entrypoints/yarn-entrypoint
+++ b/entrypoints/yarn-entrypoint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Skip this entrypoint if `DISABLE_AUTO_INSTALL_DEPS` is set
 if [ "${DISABLE_AUTO_INSTALL_DEPS}" = "1" ]; then


### PR DESCRIPTION
This commit:
* changes Dockerfile to install dependencies with either `apk` (Alpine) or `apt-get` (Debian)
* changes entrypoint executor from `/bin/bash` to `/bin/sh` (since Alpine does not ship with bash by default)
* changes `gosu-entrypoint` to properly create user/group on either Alpine or Debian
* ensures expected mountpoint exist at least as empty directories
* changes Travis build script to build `-alpine` images
* moves Travis build script to an external file