### PR TITLE
Add newer rubies to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,18 +20,26 @@ env:
   global:
     - DOCKER_BUILDKIT=1
   jobs:
-    - RUBY_IMAGE_TAG=3.1.0        ALIAS_TAGS=3.1,latest
-    - RUBY_IMAGE_TAG=3.1.0-alpine ALIAS_TAGS=3.1-alpine,alpine
-    - RUBY_IMAGE_TAG=3.0.3        ALIAS_TAGS=3.0
-    - RUBY_IMAGE_TAG=3.0.3-alpine ALIAS_TAGS=3.0-alpine
+    - RUBY_IMAGE_TAG=3.1.2        ALIAS_TAGS=3.1,latest
+    - RUBY_IMAGE_TAG=3.1.2-alpine ALIAS_TAGS=3.1-alpine,alpine
+    - RUBY_IMAGE_TAG=3.1.1
+    - RUBY_IMAGE_TAG=3.1.1-alpine
+    - RUBY_IMAGE_TAG=3.1.0
+    - RUBY_IMAGE_TAG=3.1.0-alpine
+    - RUBY_IMAGE_TAG=3.0.4        ALIAS_TAGS=3.0
+    - RUBY_IMAGE_TAG=3.0.4-alpine ALIAS_TAGS=3.0-alpine
+    - RUBY_IMAGE_TAG=3.0.3
+    - RUBY_IMAGE_TAG=3.0.3-alpine
     - RUBY_IMAGE_TAG=3.0.2
     - RUBY_IMAGE_TAG=3.0.2-alpine
     - RUBY_IMAGE_TAG=3.0.1
     - RUBY_IMAGE_TAG=3.0.1-alpine
     - RUBY_IMAGE_TAG=3.0.0
     - RUBY_IMAGE_TAG=3.0.0-alpine
-    - RUBY_IMAGE_TAG=2.7.5        ALIAS_TAGS=2.7
-    - RUBY_IMAGE_TAG=2.7.5-alpine ALIAS_TAGS=2.7-alpine
+    - RUBY_IMAGE_TAG=2.7.6        ALIAS_TAGS=2.7
+    - RUBY_IMAGE_TAG=2.7.6-alpine ALIAS_TAGS=2.7-alpine
+    - RUBY_IMAGE_TAG=2.7.5
+    - RUBY_IMAGE_TAG=2.7.5-alpine
     - RUBY_IMAGE_TAG=2.7.4
     - RUBY_IMAGE_TAG=2.7.4-alpine
     - RUBY_IMAGE_TAG=2.7.3


### PR DESCRIPTION
This PR adds in build info for newer rubies

- 2.7.6, 2.7.6-alpine
- 3.0.3, 3.0.4, 3.0.3-alpine, 3.0.4-alpine 
- 3.1.0, 3.1.1, 3.1.2, 3.1.0-alpine, 3.1.1-alpine, 3.1.2-alpine 