### PR TITLE
Bump bundler and rubygems versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ LABEL maintainer "Michael Baudino <michael.baudino@alpine-lab.com>"
 ENV LANG="C.UTF-8"
 
 # Define dependencies base versions
-ENV RUBYGEMS_VERSION="3.3.5" \
-    BUNDLER_VERSION="2.3.5" \
+ENV RUBYGEMS_VERSION="3.3.14" \
+    BUNDLER_VERSION="2.3.14" \
     NODE_VERSION="16" \
     GOSU_VERSION="1.14"
 


### PR DESCRIPTION
This PR bumps Bundler and RubyGems to:
- [bundler@2.3.14](https://github.com/rubygems/rubygems/blob/3.3/bundler/CHANGELOG.md#2314-may-18-2022)
- [rubygems@3.3.14](https://github.com/rubygems/rubygems/blob/3.3/CHANGELOG.md#3314--2022-05-18)